### PR TITLE
Use os.Kill, os.Interrupt instead of syscall.SIGTERM, syscall.SIGINT

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"syscall"
 
 	"golang.org/x/sync/errgroup"
 	"maragu.dev/env"
@@ -32,7 +31,7 @@ func start(log *slog.Logger) error {
 	_ = env.Load()
 
 	// Catch signals to gracefully shut down the app
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Kill, os.Interrupt)
 	defer stop()
 
 	// Set up the database, which is injected as a dependency into the HTTP server


### PR DESCRIPTION
This PR replaces ` syscall.SIGTERM` and `syscall.SIGINT` with `os.Kill` and `os.Interrupt` as these are the only signal values guaranteed to be present in the `os` package on all systems. The `syscall` values will e. g. not work on Windows systems.