### PR TITLE
Add patch number to go version to allow install on Linux.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module app
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/go-chi/chi/v5 v5.2.1


### PR DESCRIPTION
Hi @markuswustenberg 

I am on Ubuntu 24.04 and **without** this change I was getting:

```shell
me@pc:~/github/gomponents-starter-kit$ make start
go: downloading go1.24 (linux/amd64)
go: download go1.24 for linux/amd64: toolchain not available
```

With this patch, coming from [this stack-overflow answer](https://stackoverflow.com/questions/78519711/toolchain-not-available-error-prevents-me-from-using-any-go-commands) (bless that site), it all installs nicely.


Thanks, have a nice day.