### PR TITLE
Upgrade Go to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module app
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-chi/chi/v5 v5.2.3


### PR DESCRIPTION
Upgrades the project from Go 1.24.0 to Go 1.25.0.

Fixes #34

Generated with [Claude Code](https://claude.ai/code)